### PR TITLE
add missing compile step to 'running-rntesterexamples' documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ commands from the root of the monorepo:
 git submodule update --init
 
 # install dependencies
-yarn
+yarn && yarn compile
 
 # start the react-native packager
 yarn run-examples


### PR DESCRIPTION
It seems that packages `rndom-redbox` and `rndom-switch` need to be compiled in order to run the Examples.