### PR TITLE
chore: temporarily test against Node.js 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 aliases:
   container_config: &container_config
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     working_directory: ~/react-native-dom
-  
+
   restore_repo: &restore_repo
     restore_cache:
       keys:


### PR DESCRIPTION
To see if there are any issues with Node.js 10. We should test Node.js 8 and 10 to keep track of this.

This PR is only meant to start a fresh test build using Node.js 10 and see what happens.