### PR TITLE
Change references to react-native-windows

### DIFF
--- a/packages/react-native-dom/RNTester.md
+++ b/packages/react-native-dom/RNTester.md
@@ -1,11 +1,16 @@
 ### Update the `RNTester` branch
 
-The same example apps from `react-native` are also available for `react-native-windows`, including the [RNTester](https://github.com/facebook/react-native/tree/master/Examples/UIExplorer).
+The same example apps from `react-native` are also available for
+`react-native-dom`, including the
+[RNTester](https://github.com/facebook/react-native/tree/master/Examples/UIExplorer).
 
-We maintain a fork of the `RNTester` folder from `react-native` as a submodule of `react-native-windows`. The fork uses `git filter-branch` to produce a branch of `react-native` that includes only the content of the Examples folder. We then merge all the changes specific to `react-native-windows` with that filtered branch.
+We maintain a fork of the `RNTester` folder from `react-native` as a submodule
+of `react-native-dom`. The fork uses `git filter-branch` to produce a branch of
+`react-native` that includes only the content of the Examples folder. We then
+merge all the changes specific to `react-native-dom` with that filtered branch.
 
 ```bash
-# Be sure that you have all submodules initialized and up-to-date for react-native-windows.
+# Be sure that you have all submodules initialized and up-to-date for react-native-dom.
 cd RNTester
 
 # If you don't already have facebook/react-native set up as a Git remote...
@@ -21,10 +26,10 @@ git checkout -b fbmaster facebook/master
 # You may have to use `-f` if you've previously run a `filter-branch` command
 git filter-branch --prune-empty --subdirectory-filter RNTester fbmaster
 
-# Fetch the latest from react-native-windows
+# Fetch the latest from react-native-dom
 git fetch origin
 
-# Create a new staging branch to perform a merge onto the react-native-windows `examples` branch
+# Create a new staging branch to perform a merge onto the react-native-dom `examples` branch
 git checkout -b staging origin/rntester
 
 # Merge the latest from facebook/react-native RNTester and resolve any merge conflicts
@@ -36,9 +41,9 @@ git merge fbmaster
 git checkout rntester
 git merge staging
 
-# Use the RNTester to test changes before pushing to react-native-windows
+# Use the RNTester to test changes before pushing to react-native-dom
 
-# Push (or PR) your changes to react-native-windows
+# Push (or PR) your changes to react-native-dom
 git push origin rntester
 
 # Cleanup your staging branches

--- a/packages/rnpm-plugin-dom/src/dom.js
+++ b/packages/rnpm-plugin-dom/src/dom.js
@@ -68,7 +68,7 @@ function getMatchingVersion(version) {
             );
           })
           .catch((error) =>
-            reject(new Error(`Could not find react-native-windows@${version}.`))
+            reject(new Error(`Could not find react-native-dom@${version}.`))
           );
       } else {
         resolve(release.version);


### PR DESCRIPTION
`react-native-windows` is referenced in a few places where I think `react-native-dom` was meant. The extra reformatting in `RNTester.md` is probably due to Prettier not having run on this file previously.