### PR TITLE
[WIP] Implement Slider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ jobs:
           paths:
             - packages/rndom-redbox/lib
             - packages/rndom-switch/lib
+            - packages/rndom-slider/lib
 
   build_rntester:
     <<: *container_config

--- a/.flowconfig
+++ b/.flowconfig
@@ -20,6 +20,7 @@
 [include]
 ./packages/rndom-redbox/
 ./packages/rndom-switch/
+./packages/rndom-slider/
 ./packages/rnpm-plugin-dom/
 
 [libs]

--- a/packages/react-native-dom/Libraries/Components/Slider/Slider.dom.js
+++ b/packages/react-native-dom/Libraries/Components/Slider/Slider.dom.js
@@ -1,15 +1,284 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  * @providesModule Slider
  * @flow
  */
-
 "use strict";
 
-module.exports = require("UnimplementedView");
+const Image = require("Image");
+const ColorPropType = require("ColorPropType");
+const NativeMethodsMixin = require("NativeMethodsMixin");
+const ReactNativeViewAttributes = require("ReactNativeViewAttributes");
+const Platform = require("Platform");
+const React = require("React");
+const PropTypes = require("prop-types");
+const StyleSheet = require("StyleSheet");
+const ViewPropTypes = require("ViewPropTypes");
+
+const createReactClass = require("create-react-class");
+const requireNativeComponent = require("requireNativeComponent");
+
+type Event = Object;
+
+/**
+ * A component used to select a single value from a range of values.
+ *
+ * ### Usage
+ *
+ * The example below shows how to use `Slider` to change
+ * a value used by `Text`. The value is stored using
+ * the state of the root component (`App`). The same component
+ * subscribes to the `onValueChange`  of `Slider` and changes
+ * the value using `setState`.
+ *
+ *```
+ * import React from 'react';
+ * import { StyleSheet, Text, View, Slider } from 'react-native';
+ *
+ * export default class App extends React.Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = {
+ *       value: 50
+ *     }
+ *   }
+ *
+ *   change(value) {
+ *     this.setState(() => {
+ *       return {
+ *         value: parseFloat(value)
+ *       };
+ *     });
+ *   }
+ *
+ *   render() {
+ *     const {value} = this.state;
+ *     return (
+ *       <View style={styles.container}>
+ *         <Text style={styles.text}>{String(value)}</Text>
+ *         <Slider
+ *           step={1}
+ *           maximumValue={100}
+ *           onValueChange={this.change.bind(this)}
+ *           value={value} />
+ *       </View>
+ *     );
+ *   }
+ * }
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     flexDirection: 'column',
+ *     justifyContent: 'center'
+ *   },
+ *   text: {
+ *     fontSize: 50,
+ *     textAlign: 'center'
+ *   }
+ * });
+ *```
+ *
+ */
+const Slider = createReactClass({
+  displayName: "Slider",
+  mixins: [NativeMethodsMixin],
+
+  propTypes: {
+    ...ViewPropTypes,
+
+    /**
+     * Used to style and layout the `Slider`.  See `StyleSheet.js` and
+     * `ViewStylePropTypes.js` for more info.
+     */
+    style: ViewPropTypes.style,
+
+    /**
+     * Initial value of the slider. The value should be between minimumValue
+     * and maximumValue, which default to 0 and 1 respectively.
+     * Default value is 0.
+     *
+     * *This is not a controlled component*, you don't need to update the
+     * value during dragging.
+     */
+    value: PropTypes.number,
+
+    /**
+     * Step value of the slider. The value should be
+     * between 0 and (maximumValue - minimumValue).
+     * Default value is 0.
+     */
+    step: PropTypes.number,
+
+    /**
+     * Initial minimum value of the slider. Default value is 0.
+     */
+    minimumValue: PropTypes.number,
+
+    /**
+     * Initial maximum value of the slider. Default value is 1.
+     */
+    maximumValue: PropTypes.number,
+
+    /**
+     * The color used for the track to the left of the button.
+     * Overrides the default blue gradient image on iOS.
+     */
+    minimumTrackTintColor: ColorPropType,
+
+    /**
+     * The color used for the track to the right of the button.
+     * Overrides the default blue gradient image on iOS.
+     */
+    maximumTrackTintColor: ColorPropType,
+
+    /**
+     * If true the user won't be able to move the slider.
+     * Default value is false.
+     */
+    disabled: PropTypes.bool,
+
+    /**
+     * Assigns a single image for the track. Only static images are supported.
+     * The center pixel of the image will be stretched to fill the track.
+     * @platform ios
+     */
+    trackImage: Image.propTypes.source,
+
+    /**
+     * Assigns a minimum track image. Only static images are supported. The
+     * rightmost pixel of the image will be stretched to fill the track.
+     * @platform ios
+     */
+    minimumTrackImage: Image.propTypes.source,
+
+    /**
+     * Assigns a maximum track image. Only static images are supported. The
+     * leftmost pixel of the image will be stretched to fill the track.
+     * @platform ios
+     */
+    maximumTrackImage: Image.propTypes.source,
+
+    /**
+     * Sets an image for the thumb. Only static images are supported.
+     * @platform ios
+     */
+    thumbImage: Image.propTypes.source,
+
+    /**
+     * Color of the foreground switch grip.
+     * @platform android
+     */
+    thumbTintColor: ColorPropType,
+
+    /**
+     * Callback continuously called while the user is dragging the slider.
+     */
+    onValueChange: PropTypes.func,
+
+    /**
+     * Callback that is called when the user releases the slider,
+     * regardless if the value has changed. The current value is passed
+     * as an argument to the callback handler.
+     */
+    onSlidingComplete: PropTypes.func,
+
+    /**
+     * Used to locate this view in UI automation tests.
+     */
+    testID: PropTypes.string
+  },
+
+  getDefaultProps: function(): any {
+    return {
+      disabled: false,
+      value: 0,
+      minimumValue: 0,
+      maximumValue: 1,
+      step: 0
+    };
+  },
+
+  viewConfig: {
+    uiViewClassName: "RCTSlider",
+    validAttributes: {
+      ...ReactNativeViewAttributes.RCTView,
+      value: true
+    }
+  },
+
+  render: function() {
+    const { style, onValueChange, onSlidingComplete, ...props } = this.props;
+    /* $FlowFixMe(>=0.54.0 site=react_native_fb,react_native_oss) This comment
+     * suppresses an error found when Flow v0.54 was deployed. To see the error
+     * delete this comment and run Flow. */
+    props.style = [styles.slider, style];
+
+    /* $FlowFixMe(>=0.54.0 site=react_native_fb,react_native_oss) This comment
+     * suppresses an error found when Flow v0.54 was deployed. To see the error
+     * delete this comment and run Flow. */
+    props.onValueChange =
+      onValueChange &&
+      ((event: Event) => {
+        let userEvent = true;
+        if (Platform.OS === "android") {
+          // On Android there's a special flag telling us the user is
+          // dragging the slider.
+          userEvent = event.nativeEvent.fromUser;
+        }
+        onValueChange && userEvent && onValueChange(event.nativeEvent.value);
+      });
+
+    /* $FlowFixMe(>=0.54.0 site=react_native_fb,react_native_oss) This comment
+     * suppresses an error found when Flow v0.54 was deployed. To see the error
+     * delete this comment and run Flow. */
+    props.onChange = props.onValueChange;
+
+    /* $FlowFixMe(>=0.54.0 site=react_native_fb,react_native_oss) This comment
+     * suppresses an error found when Flow v0.54 was deployed. To see the error
+     * delete this comment and run Flow. */
+    props.onSlidingComplete =
+      onSlidingComplete &&
+      ((event: Event) => {
+        onSlidingComplete && onSlidingComplete(event.nativeEvent.value);
+      });
+
+    return (
+      <RCTSlider
+        {...props}
+        enabled={!this.props.disabled}
+        onStartShouldSetResponder={() => true}
+        onResponderTerminationRequest={() => false}
+      />
+    );
+  }
+});
+
+let styles;
+if (Platform.OS === "ios" || Platform.OS === "dom") {
+  styles = StyleSheet.create({
+    slider: {
+      height: 40
+    }
+  });
+} else {
+  styles = StyleSheet.create({
+    slider: {}
+  });
+}
+
+let options = {};
+if (Platform.OS === "android") {
+  options = {
+    nativeOnly: {
+      enabled: true
+    }
+  };
+}
+const RCTSlider = requireNativeComponent("RCTSlider", Slider, options);
+
+module.exports = Slider;

--- a/packages/react-native-dom/ReactDom/index.js
+++ b/packages/react-native-dom/ReactDom/index.js
@@ -75,6 +75,7 @@ const builtInNativeModules: any[] = [
   import("RCTWebSocketModule"),
   import("RCTAppState"),
   import("RCTSafeAreaViewManager"),
+  import("RCTSliderManager"),
   import("RCTSwitchManager"),
   import("RCTStatusBarManager"),
   import("RCTDeviceEventManager"),

--- a/packages/react-native-dom/ReactDom/views/Slider/RCTSlider.js
+++ b/packages/react-native-dom/ReactDom/views/Slider/RCTSlider.js
@@ -1,0 +1,128 @@
+/**
+ * @providesModule RCTSlider
+ * @flow
+ */
+
+import type { Frame } from "InternalLib";
+import RCTView from "RCTView";
+import type RCTBridge from "RCTBridge";
+import CustomElement from "CustomElement";
+import ColorArrayFromHexARGB from "ColorArrayFromHexARGB";
+import Slider from "rndom-slider";
+
+@CustomElement("rct-slider")
+class RCTSlider extends RCTView {
+  bridge: RCTBridge;
+  onValueChange: ?(payload: { value: boolean }) => void;
+  onSlidingComplete: ?(payload: { value: boolean }) => void;
+  childShadowRoot: ShadowRoot;
+  platformSlider: Slider;
+
+  constructor(bridge: RCTBridge) {
+    super(bridge);
+
+    this.style.contain = "size layout style";
+
+    this.platformSlider = new Slider();
+    this.platformSlider.addEventListener(
+      "valueChange",
+      this.handleValueChange.bind(this)
+    );
+    this.platformSlider.addEventListener(
+      "slidingComplete",
+      this.handleSlidingComplete.bind(this)
+    );
+
+    this.childShadowRoot = this.childContainer.attachShadow({ mode: "open" });
+    this.childShadowRoot.appendChild(this.platformSlider);
+  }
+
+  handleValueChange(event: {
+    preventDefault: Function,
+    detail: { value: boolean }
+  }) {
+    const {
+      detail: { value }
+    } = event;
+    event.preventDefault();
+    if (this.onValueChange) {
+      this.onValueChange({ value });
+    }
+  }
+
+  handleSlidingComplete(event: {
+    preventDefault: Function,
+    detail: { value: boolean }
+  }) {
+    const {
+      detail: { value }
+    } = event;
+    event.preventDefault();
+    if (this.onSlidingComplete) {
+      this.onSlidingComplete({ value });
+    }
+  }
+
+  get frame(): Frame {
+    return super.frame;
+  }
+
+  set frame(value: Frame) {
+    super.frame = value;
+
+    const { width, height } = value;
+    this.platformSlider.width = width;
+    this.platformSlider.height = height;
+  }
+
+  set disabled(value: boolean = false) {
+    super.disabled = value;
+    this.platformSlider.disabled = value;
+  }
+
+  set value(value: number = 0) {
+    this.platformSlider.value = value;
+  }
+
+  set step(value: number = 0) {
+    this.platformSlider.step = value;
+  }
+
+  set trackImage(value: mixed) {
+    this.platformSlider.trackImage = value;
+  }
+
+  set minimumTrackImage(value: mixed) {
+    this.platformSlider.minimumTrackImage = value;
+  }
+
+  set maximumTrackImage(value: mixed) {
+    this.platformSlider.maximumTrackImage = value;
+  }
+
+  set minimumValue(value: number) {
+    this.platformSlider.minimumValue = value;
+  }
+
+  set maximumValue(value: number) {
+    this.platformSlider.maximumValue = value;
+  }
+
+  set minimumTrackTintColor(value: string) {
+    this.platformSlider.minimumTrackTintColor = value;
+  }
+
+  set maximumTrackTintColor(value: string) {
+    this.platformSlider.maximumTrackTintColor = value;
+  }
+
+  set thumbImage(value: mixed) {
+    this.platformSlider.thumbImage = value;
+  }
+
+  set thumbTintColor(value: string) {
+    this.platformSlider.thumbTintColor = value;
+  }
+}
+
+export default RCTSlider;

--- a/packages/react-native-dom/ReactDom/views/Slider/RCTSliderManager.js
+++ b/packages/react-native-dom/ReactDom/views/Slider/RCTSliderManager.js
@@ -1,0 +1,97 @@
+/**
+ * @providesModule RCTSliderManager
+ * @flow
+ */
+
+import RCTBridge, {
+  RCTFunctionTypeNormal,
+  RCT_EXPORT_METHOD,
+  RCT_EXPORT_MODULE
+} from "RCTBridge";
+import RCTSlider from "RCTSlider";
+import type UIView from "UIView";
+import _RCTViewManager from "RCTViewManager";
+
+module.exports = (async () => {
+  const RCTViewManager = await _RCTViewManager;
+  const { RCT_EXPORT_VIEW_PROP, RCT_EXPORT_DIRECT_VIEW_PROPS } = RCTViewManager;
+
+  @RCT_EXPORT_MODULE("RCTSliderManager")
+  class RCTSliderManager extends RCTViewManager {
+    view(): UIView {
+      return new RCTSlider(this.bridge);
+    }
+
+    @RCT_EXPORT_VIEW_PROP("value", "number")
+    setValue(view: RCTSlider, value: number) {
+      view.value = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("step", "number")
+    setStep(view: RCTSlider, value: number) {
+      view.step = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("trackImage", "UIImage")
+    setTrackImage(view: RCTSlider, value: mixed) {
+      view.trackImage = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("minimumTrackImage", "UIImage")
+    setMinimumTrackImage(view: RCTSlider, value: mixed) {
+      view.minimumTrackImage = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("maximumTrackImage", "UIImage")
+    setMaximumTrackImage(view: RCTSlider, value: mixed) {
+      view.maximumTrackImage = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("minimumValue", "number")
+    setMinimumValue(view: RCTSlider, value: number) {
+      view.minimumValue = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("maximumValue", "number")
+    setMaximumValue(view: RCTSlider, value: number) {
+      view.maximumValue = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("minimumTrackTintColor", "color")
+    setMinimumTrackTintColor(view: RCTSlider, value: string) {
+      view.minimumTrackTintColor = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("maximumTrackTintColor", "color")
+    setMaximumTrackTintColor(view: RCTSlider, value: string) {
+      view.maximumTrackTintColor = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("onValueChange", "RCTBubblingEventBlock")
+    setOnValueChange(view: RCTSlider, value: Function) {
+      view.onValueChange = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("onSlidingComplete", "RCTBubblingEventBlock")
+    setOnSlidingComplete(view: RCTSlider, value: Function) {
+      view.onSlidingComplete = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("thumbImage", "UIImage")
+    setThumbImage(view: RCTSlider, value: mixed) {
+      view.thumbImage = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("disabled", "boolean")
+    setDisabled(view: RCTSlider, value: boolean) {
+      view.disabled = value;
+    }
+
+    @RCT_EXPORT_VIEW_PROP("thumbTintColor", "color")
+    setThumbTintColor(view: RCTSlider, value: string) {
+      view.thumbTintColor = value;
+    }
+  }
+
+  return RCTSliderManager;
+})();

--- a/packages/react-native-dom/package.json
+++ b/packages/react-native-dom/package.json
@@ -64,6 +64,7 @@
     "pepjs": "^0.4.3",
     "resize-observer-polyfill": "^1.5.0",
     "rndom-redbox": "0.1.1",
+    "rndom-slider": "0.1.1",
     "rndom-switch": "0.1.1",
     "tinycolor2": "^1.4.1",
     "wait-port": "^0.2.2",

--- a/packages/rndom-slider/.babelrc
+++ b/packages/rndom-slider/.babelrc
@@ -1,0 +1,19 @@
+{
+  "plugins": [
+    [
+      "babel-plugin-transform-builtin-classes",
+      {
+        "globals": ["HTMLElement"]
+      }
+    ],
+    "external-helpers"
+  ],
+  "presets": [
+    [
+      "env",
+      {
+        "modules": false
+      }
+    ]
+  ]
+}

--- a/packages/rndom-slider/.gitignore
+++ b/packages/rndom-slider/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules
+public/bundle.*
+lib
+package-lock.json
+yarn.lock

--- a/packages/rndom-slider/.npmignore
+++ b/packages/rndom-slider/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/packages/rndom-slider/README.md
+++ b/packages/rndom-slider/README.md
@@ -1,0 +1,1 @@
+# React Native DOM Slider

--- a/packages/rndom-slider/package.json
+++ b/packages/rndom-slider/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "rndom-slider",
+  "version": "0.1.1",
+  "license": "MIT",
+  "author": {
+    "name": "Vincent Riemer",
+    "email": "vincentriemer+rndom@gmail.com",
+    "url": "https://vincentriemer.com"
+  },
+  "files": ["lib"],
+  "main": "lib/rndom-slider.js",
+  "module": "lib/rndom-slider.m.js",
+  "scripts": {
+    "precompile": "shx rm -rf lib",
+    "compile": "rollup -c",
+    "dev": "serve public & rollup -c -w",
+    "prepublishOnly": "yarn compile",
+    "start": "serve public",
+    "test": "shx echo 'no tests written :('"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.3",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-builtin-classes": "^0.6.1",
+    "babel-preset-env": "^1.6.1",
+    "rollup": "^0.58.1",
+    "rollup-plugin-babel": "^3.0.4",
+    "rollup-plugin-buble": "^0.19.2",
+    "rollup-plugin-commonjs": "^9.1.0",
+    "rollup-plugin-node-resolve": "^3.0.3",
+    "rollup-plugin-svelte": "^4.0.0",
+    "rollup-plugin-uglify": "^3.0.0",
+    "serve": "^6.5.1",
+    "svelte": "^2.0.0"
+  },
+  "umd:main": "lib/rndom-slider.umd.js"
+}

--- a/packages/rndom-slider/public/global.css
+++ b/packages/rndom-slider/public/global.css
@@ -1,0 +1,66 @@
+html,
+body {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  color: #333;
+  margin: 0;
+  padding: 8px;
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+a {
+  color: rgb(0, 100, 200);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+a:visited {
+  color: rgb(0, 80, 160);
+}
+
+label {
+  display: block;
+}
+
+input,
+button,
+select,
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0.4em;
+  margin: 0 0 0.5em 0;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+}
+
+input:disabled {
+  color: #ccc;
+}
+
+input[type="range"] {
+  height: 0;
+}
+
+button {
+  background-color: #f4f4f4;
+  outline: none;
+}
+
+button:active {
+  background-color: #ddd;
+}
+
+button:focus {
+  border-color: #666;
+}

--- a/packages/rndom-slider/public/index.html
+++ b/packages/rndom-slider/public/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset='utf8'>
+	<meta name='viewport' content='width=device-width'>
+
+	<title>RNDom Slider</title>
+
+	<link rel='stylesheet' href='global.css'>
+	<link rel='stylesheet' href='bundle.css'>
+</head>
+
+<body>
+	<rndom-slider></rndom-slider>
+	<script src='bundle.js'></script>
+</body>
+</html>

--- a/packages/rndom-slider/rollup.config.js
+++ b/packages/rndom-slider/rollup.config.js
@@ -1,0 +1,65 @@
+import svelte from "rollup-plugin-svelte";
+import resolve from "rollup-plugin-node-resolve";
+import commonjs from "rollup-plugin-commonjs";
+import babel from "rollup-plugin-babel";
+import uglify from "rollup-plugin-uglify";
+
+import pjson from "./package.json";
+
+const production = true; //!process.env.ROLLUP_WATCH;
+
+const baseConfig = {
+  input: "src/index.svelte",
+  plugins: [
+    svelte({
+      // enable run-time checks when not in production
+      dev: !production,
+      customElement: true
+    }),
+
+    // If you have external dependencies installed from
+    // npm, you'll most likely need these plugins. In
+    // some cases you'll need additional configuration —
+    // consult the documentation for details:
+    // https://github.com/rollup/rollup-plugin-commonjs
+    resolve(),
+    commonjs(),
+
+    // If we're building for production (npm run build
+    // instead of npm run dev), transpile and minify
+    production && babel({ exclude: "node_modules/**" }),
+    production && uglify()
+  ]
+};
+
+const baseOutput = {
+  sourcemap: true,
+  name: "RNDomSlider"
+};
+
+const entryPoints = ["main", "umd:main", "module"];
+
+const formats = {
+  main: "cjs",
+  "umd:main": "umd",
+  module: "es"
+};
+
+const createConfig = (format, file) => ({
+  ...baseConfig,
+  output: {
+    ...baseOutput,
+    format,
+    file
+  }
+});
+
+export default entryPoints
+  .map((entry) => {
+    const path = pjson[entry];
+    if (path) {
+      return createConfig(formats[entry], path);
+    }
+    return null;
+  })
+  .concat([createConfig("iife", "public/bundle.js")]);

--- a/packages/rndom-slider/src/index.svelte
+++ b/packages/rndom-slider/src/index.svelte
@@ -1,0 +1,59 @@
+<input
+	type="range"
+	style="
+		width: {width}px; 
+		height: {height}px; 
+		opacity: {disabled ? 0.5 : 1};
+		pointer-events: {disabled ? 'none' : 'auto'};
+	"
+	bind:value=value
+	on:input="input()"
+	on:change="change()"
+	on:touchend="touchEnd(event)"
+	on:mouseup="mouseUp()"
+	min="{minimumValue}"
+	max="{maximumValue}"
+	step="{step || "any"}"
+	disabled="{disabled}"
+/>
+
+<script>
+	export default {
+	  tag: "rndom-slider",
+	  data: () => ({
+	    disabled: false,
+	    value: 0,
+	    maximumValue: 1,
+	    minimumValue: 0,
+	    step: 0
+	  }),
+	  methods: {
+	    input() {
+	      const event = new CustomEvent("valueChange", {
+	        detail: { value: this.value }
+	      });
+
+	      if (this.dispatchEvent(event)) {
+	        this.set({ value: this.value });
+	      }
+	    },
+	    change() {
+	      this.emitSlidingComplete();
+	    },
+	    touchEnd(e) {
+	      e.preventDefault();
+	      this.emitSlidingComplete();
+	    },
+	    mouseUp() {
+	      this.emitSlidingComplete();
+	    },
+	    emitSlidingComplete() {
+	      const event = new CustomEvent("slidingComplete", {
+	        detail: { value: this.value }
+	      });
+
+	      this.dispatchEvent(event);
+	    }
+	  }
+	};
+</script>


### PR DESCRIPTION
Hey there, just wanted to share this early implementation of `<Slider>` based on `<input type="range">`. I've not begun to tackle styling in any way and there are probably a dozen other things that need to change before this can be considered complete. I'm doing this to learn, so any and all feedback would be appreciated.

## Status and next steps

- [x] Create `rndom-slider` Svelte component.
- [x] Port `Libraries/Components/Slider/Slider.js` as `Slider.dom.js` - specifically from [this version](https://github.com/facebook/react-native/blob/9f239d791431010f4f1bf980f57c3a7ff7bafdf4/Libraries/Components/Slider/Slider.js) to stay in sync with the rest of RNDom and particularly RNTester.
- [x] Set an explicit default height (currently 40 to match iOS).
- [x] Create `RCTSlider` and wire it up with `rndom-slider`.
- [x] Create and register `RCTSliderManager` and wire it up with `RCTSlider`.
- [x] Implement `value`, `minimumValue`, `maximumValue`, `step`, `disabled`, `onValueChange`, `onSlidingComplete`.
- [ ] Implement or remove `minimumTrackTintColor`, `maximumTrackTintColor`.
(See https://codepen.io/noahblon/pen/OyajvN)
- [ ] Implement or remove (probably remove?) `thumbImage`, `trackImage`, `minimumTrackImage`, `maximumTrackImage`.
  - [ ] If implementing, patch RNTester to enable the corresponding examples.
- [ ] Apply a consistent cross-browser visual style a la [Bootstrap](https://getbootstrap.com/docs/4.1/components/forms/#range) (also as a workaround for [this Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=807625)).
