### PR TITLE
Update metro.config.js `hasteImplModulePath`

### DIFF
--- a/packages/react-native-dom/metro.config.js
+++ b/packages/react-native-dom/metro.config.js
@@ -5,7 +5,9 @@ const blacklist = require("metro-config/src/defaults/blacklist");
 const defaultPolyfills = require("react-native/rn-get-polyfills");
 
 var config = {
-  hasteImplModulePath: require.resolve("./jest/hasteImpl"),
+  resolver: {
+    hasteImplModulePath: require.resolve("./jest/hasteImpl"),
+  },
   getProjectRoots() {
     return [
       path.resolve(__dirname),


### PR DESCRIPTION
Moving `hasteImplModulePath` into `resolver` config. This combined with https://github.com/facebook/react-native/pull/20705 will resolve issues for RN 0.57.