### PR TITLE
Register react-native-dom as an out-of-tree platform

### DIFF
--- a/packages/react-native-dom/package.json
+++ b/packages/react-native-dom/package.json
@@ -111,6 +111,14 @@
     "react-native": "~0.57.0"
   },
   "rnpm": {
+    "haste": {
+      "providesModuleNodeModules": [
+        "react-native-dom"
+      ],
+      "platforms": [
+        "dom"
+      ]
+    },
     "plugin": "./local-cli/index.js",
     "platform": "./local-cli/platform.js"
   }


### PR DESCRIPTION
Like #70, but against `v0.56`rather than `master`.

From previous PR:

React Native 0.57 [will let out-of-tree platforms register themselves](https://github.com/facebook/react-native/commit/03476a225e012a0285650780430d64fc79674f0f) using a "haste" key under the "rnpm" key in package.json. This pull will let react-native-dom get picked up by the React Native bundler.

I think a new RC should be coming up within the day, so you might be able to test this out easily soon