### PR TITLE
Refresh to use idb-keyval api v3

### DIFF
--- a/packages/react-native-dom/ReactDom/modules/RCTAsyncLocalStorage.js
+++ b/packages/react-native-dom/ReactDom/modules/RCTAsyncLocalStorage.js
@@ -55,7 +55,7 @@ class RCTAsyncLocalStorage extends RCTModule {
     const callback = this.bridge.callbackFromId(callbackId);
     Promise.all(
       keys.map((key) => {
-        return idbKeyval.delete(key);
+        return idbKeyval.del(key);
       })
     ).then(() => {
       callback();


### PR DESCRIPTION
Hi!
Nice work and talk in ReactEurope!

I just found this small issue when rendering one of my projects with this package:
<img width="1433" alt="screen shot 2018-10-08 at 17 34 58" src="https://user-images.githubusercontent.com/1702755/46632285-82e15e80-cb20-11e8-875a-d19148d7f0fb.png">

And I found that the idb-keyval package api changed in v3 and the method previously named "delete" is now named "del".

This PR is one way to fix this, another would be to change the package json and downgrade idb-keyval to v2

It is rare tho that this didn't broke the flow type check 🤔 
